### PR TITLE
Release 4.0.6.RELEASE to master

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 
     <properties>
         <assertj.version>2.6.0</assertj.version>
-        <item-renderer.version>4.0.4-SNAPSHOT</item-renderer.version>
+        <item-renderer.version>4.0.4</item-renderer.version>
         <item-scoring.version>4.0.1</item-scoring.version>
         <junit.version>4.12</junit.version>
         <mockito.version>1.10.19</mockito.version>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 
     <properties>
         <assertj.version>2.6.0</assertj.version>
-        <item-renderer.version>4.0.7</item-renderer.version>
+        <item-renderer.version>4.0.7.RELEASE</item-renderer.version>
         <item-scoring.version>4.0.2.RELEASE</item-scoring.version>
         <junit.version>4.12</junit.version>
         <mockito.version>1.10.19</mockito.version>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 
     <properties>
         <assertj.version>2.6.0</assertj.version>
-        <item-renderer.version>4.0.5</item-renderer.version>
+        <item-renderer.version>4.0.6</item-renderer.version>
         <item-scoring.version>4.0.1</item-scoring.version>
         <junit.version>4.12</junit.version>
         <mockito.version>1.10.19</mockito.version>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 
     <properties>
         <assertj.version>2.6.0</assertj.version>
-        <item-renderer.version>4.0.2</item-renderer.version>
+        <item-renderer.version>4.0.3-SNAPSHOT</item-renderer.version>
         <item-scoring.version>4.0.0</item-scoring.version>
         <junit.version>4.12</junit.version>
         <mockito.version>1.10.19</mockito.version>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <artifactId>student-common-parent</artifactId>
     <name>student-common-parent</name>
     <packaging>pom</packaging>
-    <version>4.0.4</version>
+    <version>4.0.5-SNAPSHOT</version>
 
     <parent>
         <groupId>org.opentestsystem.shared</groupId>
@@ -108,7 +108,7 @@
         <connection>scm:git:https://github.com/SmarterApp/TDS_StudentCommon.git</connection>
         <developerConnection>scm:git:git://github.com/SmarterApp/TDS_StudentCommon.git</developerConnection>
         <url>https://github.com/SmarterApp/TDS_StudentCommon</url>
-        <tag>4.0.4</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -11,12 +11,12 @@
     <parent>
         <groupId>org.opentestsystem.shared</groupId>
         <artifactId>shared-master</artifactId>
-        <version>4.0.5</version>
+        <version>4.0.6.RELEASE</version>
     </parent>
 
     <properties>
         <assertj.version>2.6.0</assertj.version>
-        <item-renderer.version>4.0.6</item-renderer.version>
+        <item-renderer.version>4.0.7</item-renderer.version>
         <item-scoring.version>4.0.1</item-scoring.version>
         <junit.version>4.12</junit.version>
         <mockito.version>1.10.19</mockito.version>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <artifactId>student-common-parent</artifactId>
     <name>student-common-parent</name>
     <packaging>pom</packaging>
-    <version>4.0.4-SNAPSHOT</version>
+    <version>4.0.4</version>
 
     <parent>
         <groupId>org.opentestsystem.shared</groupId>
@@ -108,7 +108,7 @@
         <connection>scm:git:https://github.com/SmarterApp/TDS_StudentCommon.git</connection>
         <developerConnection>scm:git:git://github.com/SmarterApp/TDS_StudentCommon.git</developerConnection>
         <url>https://github.com/SmarterApp/TDS_StudentCommon</url>
-        <tag>HEAD</tag>
+        <tag>4.0.4</tag>
     </scm>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 
     <properties>
         <assertj.version>2.6.0</assertj.version>
-        <item-renderer.version>4.0.3</item-renderer.version>
+        <item-renderer.version>4.0.4-SNAPSHOT</item-renderer.version>
         <item-scoring.version>4.0.1</item-scoring.version>
         <junit.version>4.12</junit.version>
         <mockito.version>1.10.19</mockito.version>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <artifactId>student-common-parent</artifactId>
     <name>student-common-parent</name>
     <packaging>pom</packaging>
-    <version>4.0.1</version>
+    <version>4.0.2-SNAPSHOT</version>
 
     <parent>
         <groupId>org.opentestsystem.shared</groupId>
@@ -108,7 +108,7 @@
         <connection>scm:git:https://github.com/SmarterApp/TDS_StudentCommon.git</connection>
         <developerConnection>scm:git:git://github.com/SmarterApp/TDS_StudentCommon.git</developerConnection>
         <url>https://github.com/SmarterApp/TDS_StudentCommon</url>
-        <tag>4.0.1</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <artifactId>student-common-parent</artifactId>
     <name>student-common-parent</name>
     <packaging>pom</packaging>
-    <version>4.0.2-SNAPSHOT</version>
+    <version>4.0.2</version>
 
     <parent>
         <groupId>org.opentestsystem.shared</groupId>
@@ -108,7 +108,7 @@
         <connection>scm:git:https://github.com/SmarterApp/TDS_StudentCommon.git</connection>
         <developerConnection>scm:git:git://github.com/SmarterApp/TDS_StudentCommon.git</developerConnection>
         <url>https://github.com/SmarterApp/TDS_StudentCommon</url>
-        <tag>HEAD</tag>
+        <tag>4.0.2</tag>
     </scm>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <artifactId>student-common-parent</artifactId>
     <name>student-common-parent</name>
     <packaging>pom</packaging>
-    <version>4.0.5</version>
+    <version>4.0.6-SNAPSHOT</version>
 
     <parent>
         <groupId>org.opentestsystem.shared</groupId>
@@ -108,7 +108,7 @@
         <connection>scm:git:https://github.com/SmarterApp/TDS_StudentCommon.git</connection>
         <developerConnection>scm:git:git://github.com/SmarterApp/TDS_StudentCommon.git</developerConnection>
         <url>https://github.com/SmarterApp/TDS_StudentCommon</url>
-        <tag>4.0.5</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 
     <properties>
         <assertj.version>2.6.0</assertj.version>
-        <item-renderer.version>4.0.2.RELEASE</item-renderer.version>
+        <item-renderer.version>4.0.6</item-renderer.version>
         <item-scoring.version>4.0.2.RELEASE</item-scoring.version>
         <junit.version>4.12</junit.version>
         <mockito.version>1.10.19</mockito.version>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 
     <properties>
         <assertj.version>2.6.0</assertj.version>
-        <item-renderer.version>4.0.4</item-renderer.version>
+        <item-renderer.version>4.0.5</item-renderer.version>
         <item-scoring.version>4.0.1</item-scoring.version>
         <junit.version>4.12</junit.version>
         <mockito.version>1.10.19</mockito.version>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <artifactId>student-common-parent</artifactId>
     <name>student-common-parent</name>
     <packaging>pom</packaging>
-    <version>4.0.2</version>
+    <version>4.0.3-SNAPSHOT</version>
 
     <parent>
         <groupId>org.opentestsystem.shared</groupId>
@@ -108,7 +108,7 @@
         <connection>scm:git:https://github.com/SmarterApp/TDS_StudentCommon.git</connection>
         <developerConnection>scm:git:git://github.com/SmarterApp/TDS_StudentCommon.git</developerConnection>
         <url>https://github.com/SmarterApp/TDS_StudentCommon</url>
-        <tag>4.0.2</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <artifactId>student-common-parent</artifactId>
     <name>student-common-parent</name>
     <packaging>pom</packaging>
-    <version>4.0.6-SNAPSHOT</version>
+    <version>4.0.6.RELEASE</version>
 
     <parent>
         <groupId>org.opentestsystem.shared</groupId>
@@ -108,7 +108,7 @@
         <connection>scm:git:https://github.com/SmarterApp/TDS_StudentCommon.git</connection>
         <developerConnection>scm:git:git://github.com/SmarterApp/TDS_StudentCommon.git</developerConnection>
         <url>https://github.com/SmarterApp/TDS_StudentCommon</url>
-        <tag>HEAD</tag>
+        <tag>4.0.6.RELEASE</tag>
     </scm>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <artifactId>student-common-parent</artifactId>
     <name>student-common-parent</name>
     <packaging>pom</packaging>
-    <version>4.0.5-SNAPSHOT</version>
+    <version>4.0.5</version>
 
     <parent>
         <groupId>org.opentestsystem.shared</groupId>
@@ -108,7 +108,7 @@
         <connection>scm:git:https://github.com/SmarterApp/TDS_StudentCommon.git</connection>
         <developerConnection>scm:git:git://github.com/SmarterApp/TDS_StudentCommon.git</developerConnection>
         <url>https://github.com/SmarterApp/TDS_StudentCommon</url>
-        <tag>HEAD</tag>
+        <tag>4.0.5</tag>
     </scm>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <artifactId>student-common-parent</artifactId>
     <name>student-common-parent</name>
     <packaging>pom</packaging>
-    <version>4.0.1.RELEASE</version>
+    <version>4.0.5-SNAPSHOT</version>
 
     <parent>
         <groupId>org.opentestsystem.shared</groupId>
@@ -108,7 +108,7 @@
         <connection>scm:git:https://github.com/SmarterApp/TDS_StudentCommon.git</connection>
         <developerConnection>scm:git:git://github.com/SmarterApp/TDS_StudentCommon.git</developerConnection>
         <url>https://github.com/SmarterApp/TDS_StudentCommon</url>
-        <tag>4.0.1.RELEASE</tag>
+        <tag>4.0.1</tag>
     </scm>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <artifactId>student-common-parent</artifactId>
     <name>student-common-parent</name>
     <packaging>pom</packaging>
-    <version>4.0.3</version>
+    <version>4.0.4-SNAPSHOT</version>
 
     <parent>
         <groupId>org.opentestsystem.shared</groupId>
@@ -108,7 +108,7 @@
         <connection>scm:git:https://github.com/SmarterApp/TDS_StudentCommon.git</connection>
         <developerConnection>scm:git:git://github.com/SmarterApp/TDS_StudentCommon.git</developerConnection>
         <url>https://github.com/SmarterApp/TDS_StudentCommon</url>
-        <tag>4.0.3</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <artifactId>student-common-parent</artifactId>
     <name>student-common-parent</name>
     <packaging>pom</packaging>
-    <version>4.0.3-SNAPSHOT</version>
+    <version>4.0.3</version>
 
     <parent>
         <groupId>org.opentestsystem.shared</groupId>
@@ -108,7 +108,7 @@
         <connection>scm:git:https://github.com/SmarterApp/TDS_StudentCommon.git</connection>
         <developerConnection>scm:git:git://github.com/SmarterApp/TDS_StudentCommon.git</developerConnection>
         <url>https://github.com/SmarterApp/TDS_StudentCommon</url>
-        <tag>HEAD</tag>
+        <tag>4.0.3</tag>
     </scm>
 
     <distributionManagement>

--- a/student-library/pom.xml
+++ b/student-library/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.opentestsystem.delivery</groupId>
         <artifactId>student-common-parent</artifactId>
-        <version>4.0.2-SNAPSHOT</version>
+        <version>4.0.2</version>
     </parent>
 
     <properties>

--- a/student-library/pom.xml
+++ b/student-library/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.opentestsystem.delivery</groupId>
         <artifactId>student-common-parent</artifactId>
-        <version>4.0.1.RELEASE</version>
+        <version>4.0.5-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/student-library/pom.xml
+++ b/student-library/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.opentestsystem.delivery</groupId>
         <artifactId>student-common-parent</artifactId>
-        <version>4.0.5</version>
+        <version>4.0.6-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/student-library/pom.xml
+++ b/student-library/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.opentestsystem.delivery</groupId>
         <artifactId>student-common-parent</artifactId>
-        <version>4.0.1</version>
+        <version>4.0.2-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/student-library/pom.xml
+++ b/student-library/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.opentestsystem.delivery</groupId>
         <artifactId>student-common-parent</artifactId>
-        <version>4.0.4-SNAPSHOT</version>
+        <version>4.0.4</version>
     </parent>
 
     <properties>

--- a/student-library/pom.xml
+++ b/student-library/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.opentestsystem.delivery</groupId>
         <artifactId>student-common-parent</artifactId>
-        <version>4.0.3</version>
+        <version>4.0.4-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/student-library/pom.xml
+++ b/student-library/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.opentestsystem.delivery</groupId>
         <artifactId>student-common-parent</artifactId>
-        <version>4.0.4</version>
+        <version>4.0.5-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/student-library/pom.xml
+++ b/student-library/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.opentestsystem.delivery</groupId>
         <artifactId>student-common-parent</artifactId>
-        <version>4.0.3-SNAPSHOT</version>
+        <version>4.0.3</version>
     </parent>
 
     <properties>

--- a/student-library/pom.xml
+++ b/student-library/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.opentestsystem.delivery</groupId>
         <artifactId>student-common-parent</artifactId>
-        <version>4.0.5-SNAPSHOT</version>
+        <version>4.0.5</version>
     </parent>
 
     <properties>

--- a/student-library/pom.xml
+++ b/student-library/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.opentestsystem.delivery</groupId>
         <artifactId>student-common-parent</artifactId>
-        <version>4.0.6-SNAPSHOT</version>
+        <version>4.0.6.RELEASE</version>
     </parent>
 
     <properties>

--- a/student-library/pom.xml
+++ b/student-library/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.opentestsystem.delivery</groupId>
         <artifactId>student-common-parent</artifactId>
-        <version>4.0.2</version>
+        <version>4.0.3-SNAPSHOT</version>
     </parent>
 
     <properties>


### PR DESCRIPTION
Merge 4.0.6.RELEASE tag to master.  This release bumps the version of item renderer to 4.0.7.RELEASE (its latest version)